### PR TITLE
MySQL Compatibility

### DIFF
--- a/db/post.py
+++ b/db/post.py
@@ -9,13 +9,13 @@ class Post(Base):
     __tablename__ = 'posts'
 
     id = Column(Integer, primary_key=True)
-    user = Column(String, nullable=False)
-    poster = Column(String, nullable=False)
-    value = Column(String, nullable=False)
-    text = Column(String, nullable=False)
+    user = Column(String(64), nullable=False)
+    poster = Column(String(64), nullable=False)
+    value = Column(String(64), nullable=False)
+    text = Column(String(500), nullable=False)
     posted_at = Column(DateTime, nullable=False)
-    slack_timestamp = Column(String, nullable=False)
-    slack_channel = Column(String, nullable=False)
+    slack_timestamp = Column(String(64), nullable=False)
+    slack_channel = Column(String(64), nullable=False)
 
     def __init__(self, user, poster, value, text, slack_timestamp, slack_channel, posted_at=None):
         self.user = user

--- a/migrations/versions/16c93656a0de_initial_schema.py
+++ b/migrations/versions/16c93656a0de_initial_schema.py
@@ -20,13 +20,13 @@ def upgrade():
     op.create_table(
         'posts',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('user', sa.String, nullable=False),
-        sa.Column('poster', sa.String, nullable=False),
-        sa.Column('value', sa.String, nullable=False),
-        sa.Column('text', sa.String, nullable=False),
+        sa.Column('user', sa.String(64), nullable=False),
+        sa.Column('poster', sa.String(64), nullable=False),
+        sa.Column('value', sa.String(64), nullable=False),
+        sa.Column('text', sa.String(500), nullable=False),
         sa.Column('posted_at', sa.DateTime, nullable=False),
-        sa.Column('slack_timestamp', sa.String, nullable=False),
-        sa.Column('slack_channel', sa.String, nullable=False))
+        sa.Column('slack_timestamp', sa.String(64), nullable=False),
+        sa.Column('slack_channel', sa.String(64), nullable=False))
 
 def downgrade():
     op.drop_table('posts')


### PR DESCRIPTION
Adds compatibility within SQLAlchemy for MySQL databases, which wasn't fully supported before.
